### PR TITLE
feat: Update website styling to a professional blue and grey theme

### DIFF
--- a/acap-resume-builder/src/App.css
+++ b/acap-resume-builder/src/App.css
@@ -1,9 +1,10 @@
 :root {
-  --primary-color: #4A5C43; /* Deep forest green */
-  --secondary-color: #A4B494; /* Sage green */
-  --background-color: #F4F3EE; /* Light beige/off-white */
+  --primary-color: #004a99; /* A professional blue */
+  --secondary-color: #6c757d; /* A neutral grey */
+  --background-color: #f8f9fa; /* A very light grey */
   --text-color: #333;
-  --border-color: #DDE2C6; /* Light olive green */
+  --border-color: #dee2e6; /* A light grey for borders */
+  --accent-color: #007bff; /* A brighter blue for links and highlights */
 }
 
 body {

--- a/acap-resume-builder/src/index.css
+++ b/acap-resume-builder/src/index.css
@@ -1,68 +1,16 @@
-:root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 a {
   font-weight: 500;
-  color: #646cff;
+  color: var(--primary-color);
   text-decoration: inherit;
 }
+
 a:hover {
-  color: #535bf2;
-}
-
-body {
-  margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+  color: var(--accent-color);
 }


### PR DESCRIPTION
This commit updates the website's color scheme and typography to give it a more professional look and feel.

- The color variables in `src/App.css` have been changed to a blue and grey palette.
- The base font in `src/index.css` has been updated to a cleaner, more modern font stack.
- The `a:hover` color now correctly uses the `--accent-color` variable.