### PR TITLE
feat: Add content to home page and update styling

### DIFF
--- a/acap-resume-builder/src/pages/Home.jsx
+++ b/acap-resume-builder/src/pages/Home.jsx
@@ -2,14 +2,27 @@ import React from 'react';
 
 function Home() {
   return (
-    <div>
+    <div className="container">
       <h1>ACAP Job Readiness Workshop</h1>
       <p>Welcome to the Aroostook County Action Program (ACAP) Job Readiness Workshop. This self-paced course is designed to provide you with the skills, strategies, and confidence you need to succeed in your job search.</p>
-      {/* Based on the sitemap, this page should have: Welcome Video, Course Overview, How to Use This Site */}
-      <h2>Course Overview</h2>
-      <p>This course is divided into three modules...</p>
-      <h2>How to Use This Site</h2>
-      <p>Navigate through the course using the menu above...</p>
+
+      <h2>Who We Help</h2>
+      <p>Our Workforce Development Team offers individualized training and employment opportunities for jobseekers from Aroostook County to the City of Calais in Washington County and towns located north of Calais in Washington County.</p>
+
+      <h2>Our Services</h2>
+      <ul>
+        <li>Assistance identifying career goals and building achievable plans</li>
+        <li>Overcoming barriers to employment</li>
+        <li>Access to funding for occupational or on-the-job training</li>
+        <li>Connection to high-quality job opportunities</li>
+        <li>Resume building and interview preparation</li>
+      </ul>
+
+      <h2>How It Works</h2>
+      <p>This self-paced workshop is divided into modules that you can complete at your own convenience. Navigate through the course using the menu above to get started.</p>
+
+      <h2>Get Started</h2>
+      <p>Ready to take the next step in your career? Log in or create an account to begin the workshop and access all of our resources.</p>
     </div>
   );
 }


### PR DESCRIPTION
This commit introduces two main changes:

1.  The home page has been updated with new content sections, including "Who We Help", "Our Services", "How It Works", and "Get Started". The content is based on the ACAP Workforce Development website and is structured in a "chunked" format for easy readability.

2.  The website's styling has been updated to a professional blue and grey theme. The color variables in `src/App.css` have been changed, and the base font in `src/index.css` has been updated.